### PR TITLE
Update nginx ECS config to match development configuration

### DIFF
--- a/nginx_ecs.conf
+++ b/nginx_ecs.conf
@@ -1,3 +1,7 @@
+upstream django {
+    server localhost:8000;
+}
+
 server {
     listen 80 default_server;
     server_name localhost;
@@ -10,22 +14,31 @@ server {
 
     location = /favicon.ico { access_log off; log_not_found off; }
 
+    # Serve static files
     location /static/ {
         alias /app/newsloom/static/;
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
     }
 
-
-    location / {
-        root /app/dist;  
-        try_files $uri /index.html;  
-    }
-
+    # Serve media files
     location /media/ {
         alias /app/newsloom/media/;
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
     }
 
+    # Frontend files
+    location /frontend/ {
+        alias /app/dist/;
+        try_files $uri $uri/ /frontend/index.html;
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
+    }
+
+    # WebSocket connections
     location /ws/ {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://django;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -36,20 +49,39 @@ server {
         proxy_read_timeout 86400;
     }
 
+    # API endpoints
     location /api/ {
-    proxy_pass http://127.0.0.1:8000; 
-    proxy_set_header Host $host; 
-    proxy_set_header X-Real-IP $remote_addr; 
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme; 
-}
+        proxy_pass http://django;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
 
+    # Admin interface
     location /admin/ {
-            proxy_pass http://127.0.0.1:8000;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
+        proxy_pass http://django;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
 
+    # Default location - proxy to Django
+    location / {
+        proxy_pass http://django;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
 }


### PR DESCRIPTION
- Add upstream django configuration
- Configure admin routes to proxy to django
- Configure API routes to proxy to django
- Create dedicated /frontend/ location
- Standardize proxy headers and settings
- Maintain ECS timeout configurations